### PR TITLE
Clear and rebuild exports file when restarting server

### DIFF
--- a/deployment/terraform-module-knfsd/resources/proxy-startup.sh
+++ b/deployment/terraform-module-knfsd/resources/proxy-startup.sh
@@ -226,6 +226,8 @@ else
   FSC=
 fi
 
+# Truncate the exports file to avoid stale/duplicate exports if the server restarts
+: > /etc/exports
 
 # Loop through $EXPORT_MAP and mount each share defined in the EXPORT_MAP
 echo "Beginning processing of standard NFS re-exports (EXPORT_MAP)..."

--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -5,6 +5,7 @@
 * (GCP) Prevent mounting over system directories
 * (GCP) Added `EXCLUDED_EXPORTS` option to exclude exports from auto-discovery
 * (GCP) Added optional UDP load balancer
+* (GCP) Fixed remove duplicate and stale exports when restarting
 
 ## (GCP) Fixed specifying project/region/zone
 
@@ -113,3 +114,9 @@ Use Terraform to re-create the reserved address and the forwarding rules:
 ```bash
 terraform apply
 ```
+
+## (GCP) Fixed remove duplicate and stale exports when restarting
+
+The `/etc/exports` file was not cleared when running the start up script. When rebooting a proxy instance this would create duplicate entries (or leave stale entries) in the `/etc/exports` file.
+
+The `/etc/exports` file is now cleared by the start up script before appending any exports.


### PR DESCRIPTION
When restarting the server duplicates will be created in the exports file.
Also, stale exports could be left in the exports file.

On start up, clear and rebuild the exports file.