### PR TITLE
Fix typos in v0.4.0 release notes and deployment README.md

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a [Terraform Module](https://www.terraform.io/docs/modules/index.html) for deploying a Knfsd cluster on Google Cloud.
 
-**Note:** The master branch may be updated at any time with the latest changes which could be breaking. You should always configure your module to use a release. This can be configured in the modules Terraform Configuration block.
+**Note:** The `main` branch may be updated at any time with the latest changes which could be breaking. You should always configure your module to use a release. This can be configured in the modules Terraform Configuration block.
 
 ```
 source = "github.com/GoogleCloudPlatform/knfsd-cache-utils//deployment/terraform-module-knfsd?ref=v0.4.0"

--- a/docs/changes/v0.4.0.md
+++ b/docs/changes/v0.4.0.md
@@ -1,4 +1,4 @@
-# Next
+# v0.4.0
 
 * (GCP) Fixed specifying project/region/zone
 * (GCP) Changed `LOCAL_SSDS` to a simple count of the number of drives.


### PR DESCRIPTION
This PR fixes a typo in the title of the v0.4.0 release notes and corrects an incorrect branch name in `deployment/README.md`.