### PR TITLE
Implement a new knfsd-agent which provides a HTTP API for interacting with Knfsd nodes

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -74,6 +74,16 @@ You can change this behaviour if you wish, but it is not recommended.
 
 There is a slight delay for metric ingestion (1-2 mins) and then for a new node to spin up and initialise (~2 mins). When a scaling event occurs new traffic will continue to be sent to the existing healthy nodes in the cluster until there is a new node ready to handle the connections. It is therefore recommended that you set your `KNFSD_AUTOSCALING_NFS_CONNECTIONS_THRESHOLD` slightly lower than the maximum number of connections a single Knfsd node can handle. This will start the scaling event early and make sure a new node is ready before your existing nodes become overloaded.
 
+## Knfsd Agent
+
+By default, each Knfsd node will also run the [Knfsd Agent](../../image/knfsd-agent/README.md). This is a small Golang application that exposes a web server with some API Methods. Currently the Knfsd Agent only supports a basic informational API method (`/api/v1.0/nodeinfo`). This method provides basic information on the Knfsd node. It is useful for determining which backend node you are connected to when connecting to the Knfsd Cluster via the Internal Load Balancer.
+
+Over time this will API will be expanded with additional capabilities.
+
+This agent listens on port `80` and can be disabled by setting `ENABLE_KNFSD_AGENT` to `false` in the Terraform.
+
+For information on the API Methods, see the [Knfsd Agent README.md](../../image/knfsd-agent/README.md).
+
 ## Usage
 
 **Note: See the [Configuration Variables](#Configuration-Variables) section for advance configuration options**
@@ -231,7 +241,7 @@ terraform apply
 | MIG_MAX_UNAVAILABLE_PERCENT     | The maximum number of instances that can be unavailable during automated MIG updates ([see docs](https://cloud.google.com/compute/docs/instance-groups/rolling-out-updates-to-managed-instance-groups#max_unavailable)). Defaults to 100% to ensure consistent cache instances within the MIG.                                                                                                                                                                  | `false`                                                                                                                                                                                                                        | `100`           |
 | MIG_REPLACEMENT_METHOD          | The instance replacement method for managed instance groups. Valid values are: `RECREATE`, `SUBSTITUTE`.<br><br>If `SUBSTITUTE` (default), the group replaces VM instances with new instances that have randomly generated names. If `RECREATE`, instance names are preserved. You must also set `MIG_MAX_UNAVAILABLE_PERCENT` to be greater than 0 (default is already `100` so this only applies if you have modified this variable).                         | `false`                                                                                                                                                                                                                        | `SUBSTITUTE`    |
 | MIG_MINIMAL_ACTION              | Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.                                          | `false`                                                                                                                                                                                                                        | `RESTART`       |
-
+| ENABLE_KNFSD_AGENT              | Should the [Knfsd Agent](../../image/knfsd-agent/README.md) be started at Proxy Startup?                                                                                                                                                                                                                                                                                                                                                                                                             | `false`                                                                                                                                                                                                                        | `true`          |
 ### Mount Options
 
 These mount options are for the proxy to the source server.

--- a/deployment/terraform-module-knfsd/compute.tf
+++ b/deployment/terraform-module-knfsd/compute.tf
@@ -87,10 +87,11 @@ resource "google_compute_instance_template" "nfsproxy-template" {
     COLLECTD_METRICS_SCRIPT     = file("${path.module}/resources/monitoring/knfsd.sh")
     COLLECTD_ROOT_EXPORT_SCRIPT = file("${path.module}/resources/monitoring/export-root.sh")
 
-    # scripts
+    # scripts / software
     startup-script             = file("${path.module}/resources/proxy-startup.sh")
     CUSTOM_PRE_STARTUP_SCRIPT  = var.CUSTOM_PRE_STARTUP_SCRIPT
     CUSTOM_POST_STARTUP_SCRIPT = var.CUSTOM_POST_STARTUP_SCRIPT
+    ENABLE_KNFSD_AGENT         = var.ENABLE_KNFSD_AGENT
   }
 
   labels = {

--- a/deployment/terraform-module-knfsd/resources/proxy-startup.sh
+++ b/deployment/terraform-module-knfsd/resources/proxy-startup.sh
@@ -228,6 +228,7 @@ ENABLE_STACKDRIVER_METRICS=$(get_attribute ENABLE_STACKDRIVER_METRICS)
 COLLECTD_METRICS_CONFIG=$(get_attribute COLLECTD_METRICS_CONFIG)
 COLLECTD_METRICS_SCRIPT=$(get_attribute COLLECTD_METRICS_SCRIPT)
 COLLECTD_ROOT_EXPORT_SCRIPT=$(get_attribute COLLECTD_ROOT_EXPORT_SCRIPT)
+ENABLE_KNFSD_AGENT=$(get_attribute ENABLE_KNFSD_AGENT)
 
 CUSTOM_PRE_STARTUP_SCRIPT=$(get_attribute CUSTOM_PRE_STARTUP_SCRIPT)
 CUSTOM_POST_STARTUP_SCRIPT=$(get_attribute CUSTOM_POST_STARTUP_SCRIPT)
@@ -414,6 +415,17 @@ if [ "$ENABLE_STACKDRIVER_METRICS" = "true" ]; then
 
 else
   echo "Metrics are disabled. Skipping..."
+fi
+
+# Enable Knfsd Agent if Configured
+if [ "$ENABLE_KNFSD_AGENT" = "true" ]; then
+
+  echo "Starting Knfsd Agent..."
+  systemctl start knfsd-agent
+  echo "Finished Starting Knfsd Agent."
+
+else
+  echo "Knfsd Agent disabled. Skipping..."
 fi
 
 # Start NFS Server

--- a/deployment/terraform-module-knfsd/variables.tf
+++ b/deployment/terraform-module-knfsd/variables.tf
@@ -212,7 +212,7 @@ variable "MACHINE_TYPE" {
 
 variable "MIG_MINIMAL_ACTION" {
   default = "RESTART"
-  type = string
+  type    = string
 }
 
 variable "MIG_MAX_UNAVAILABLE_PERCENT" {
@@ -223,4 +223,9 @@ variable "MIG_MAX_UNAVAILABLE_PERCENT" {
 variable "MIG_REPLACEMENT_METHOD" {
   default = "SUBSTITUTE"
   type    = string
+}
+
+variable "ENABLE_KNFSD_AGENT" {
+  default = true
+  type    = bool
 }

--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -1,1 +1,19 @@
 # Next
+
+* (GCP) Stop reporting file system usage metrics for NFS mounts
+* (GCP) Implement the knfsd-agent which provides a HTTP API for interacting with Knfsd nodes
+
+## (GCP) Stop reporting file system usage metrics for NFS mounts
+
+The default stackdriver collectd configuration for the `df` plugin includes metrics for NFS shares. The df plugin only collects basic metrics such as disk free space, inode free space, etc.
+
+Collecting these metrics about NFS shares from the proxy is largely pointless as the same metrics are also available from the source server.
+
+If the proxy has hundreds or thousands of NFS exports mounted this can greatly increase the volume of metrics being collected, leading to excessive charges for metrics ingestion.
+
+
+## (GCP) Implement the knfsd-agent which provides a HTTP API for interacting with Knfsd nodes
+
+Implements a new Golang based knfsd-agent which runs on all Knfsd nodes. It provides a HTTP API that can be used for interacting with Knfsd nodes. [See here](../../image/knfsd-agent/README.md) for more information.
+
+If upgrading from `v.0.4.0` and below you will need to build a [new version of the Knfsd Image](../../image).

--- a/image/README.md
+++ b/image/README.md
@@ -16,7 +16,7 @@ For details of the patches that are applied, see [1_build_image.sh](scripts/1_bu
 cd image/scripts
 ```
 
-### Update settings in brackets <> below and set variables 
+### Update settings in brackets <> below and set variables
 ```
 export BUILD_MACHINE_NAME=knfsd-build-machine
 export BUILD_MACHINE_ZONE=<europe-west2-a>
@@ -29,7 +29,7 @@ export BUILD_MACHINE_SUBNET=<europe-west2-subnet>
 ```
 gcloud compute instances create $BUILD_MACHINE_NAME \
     --zone=$BUILD_MACHINE_ZONE \
-    --machine-type=c2-standard-30 \
+    --machine-type=c2-standard-16 \
     --project=$GOOGLE_CLOUD_PROJECT \
     --image=ubuntu-2010-groovy-v20210323 \
     --image-project=ubuntu-os-cloud \
@@ -46,20 +46,29 @@ gcloud compute instances create $BUILD_MACHINE_NAME \
 gcloud compute firewall-rules create allow-ssh-ingress-from-iap --direction=INGRESS --action=allow --rules=tcp:22 --source-ranges=35.235.240.0/20 --network=$BUILD_MACHINE_NETWORK --project=$GOOGLE_CLOUD_PROJECT
 ```
 
+### Copy Knfsd Agent Source Code to Machine
+```
+gcloud beta compute scp --recurse ../knfsd-agent build@$BUILD_MACHINE_NAME: --zone=$BUILD_MACHINE_ZONE --tunnel-through-iap --project=$GOOGLE_CLOUD_PROJECT
+```
+
 ### SSH to Build Machine
 ```
-gcloud beta compute ssh $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE --tunnel-through-iap
+gcloud beta compute ssh $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE --tunnel-through-iap --project=$GOOGLE_CLOUD_PROJECT
 ```
 
 ### Switch to Root
 ```
 sudo su
-```
-
-### Run the script 1_build_image.sh 
-
-```
 cd
+```
+
+# Move Knfsd Agent Source Code
+```
+mv /home/build/knfsd-agent .
+```
+
+### Run the script 1_build_image.sh
+```
 ./1_build_image.sh
 ```
 
@@ -71,7 +80,7 @@ reboot
 
 ### SSH to your Build Machine to run subsequent commands.
 ```
-gcloud beta compute ssh $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE --tunnel-through-iap
+gcloud beta compute ssh $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE --tunnel-through-iap --project=$GOOGLE_CLOUD_PROJECT
 ```
 
 ### Switch to Root
@@ -92,10 +101,10 @@ sudo shutdown -h now
 
 ### On your Cloud Shell host machine, create the Custom Disk Image
 ```
-gcloud compute images create knfsd-image --source-disk=$BUILD_MACHINE_NAME --source-disk-zone=$BUILD_MACHINE_ZONE
+gcloud compute images create knfsd-image --source-disk=$BUILD_MACHINE_NAME --source-disk-zone=$BUILD_MACHINE_ZONE --project=$GOOGLE_CLOUD_PROJECT
 ```
 
 ### Delete Build Machine
 ```
-gcloud compute instances delete $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE
+gcloud compute instances delete $BUILD_MACHINE_NAME --zone=$BUILD_MACHINE_ZONE --project=$GOOGLE_CLOUD_PROJECT
 ```

--- a/image/knfsd-agent/README.md
+++ b/image/knfsd-agent/README.md
@@ -1,0 +1,32 @@
+# knfsd-agent
+
+By default, each Knfsd node will also run the [Knfsd Agent](../../image/knfsd-agent/README.md).
+
+This is a small Golang application that exposes a web server with some API Methods. Currently the Knfsd Agent only supports a basic informational API method (`/api/v1.0/nodeinfo`). This method provides basic information on the Knfsd node. It is useful for determining which backend node you are connected to when connecting to the Knfsd Cluster via the Internal Load Balancer.
+
+Over time this will API will be expanded with additional capabilities.
+
+This agent listens on port `80` and can be disabled by setting `ENABLE_KNFSD_AGENT` to `false` in the Terraform.
+
+## Methods
+
+### GET /api/v1.0/nodeinfo
+
+Note: This method is also accessible via `/`
+
+This method provides basic information on the Knfsd node. It is useful for determining which backend node you are connected to when connecting via the internal load balancer.
+
+```
+{
+  "name": "nfsproxy-hr7s",
+  "hostname": "nfsproxy-hr7s.europe-west2-a.c.xxx.internal",
+  "interfaceConfig": {
+    "ipAddress": "10.67.4.79",
+    "networkName": "knfsd-demo-vpc",
+    "networkURI": "projects/123/networks/knfsd-demo-vpc"
+  },
+  "zone": "europe-west2-a",
+  "machineType": "n1-highmem-16",
+  "image": "projects/xxx/global/images/knfsd-image"
+}
+```

--- a/image/knfsd-agent/knfsd-agent.service
+++ b/image/knfsd-agent/knfsd-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Knfsd Agent
+After=network.target
+StartLimitIntervalSec=0
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+ExecStart=/usr/local/bin/knfsd-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/image/knfsd-agent/knfsd-logrotate.conf
+++ b/image/knfsd-agent/knfsd-logrotate.conf
@@ -1,0 +1,7 @@
+/var/log/knfsd-agent/* {
+    weekly
+    rotate 3
+    size 10M
+    compress
+    delaycompress
+}

--- a/image/knfsd-agent/src/go.mod
+++ b/image/knfsd-agent/src/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/knfsd-cache-utils/image/knfsd-agent/src
+
+go 1.17

--- a/image/knfsd-agent/src/main.go
+++ b/image/knfsd-agent/src/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+const (
+	apiVersion = "1.0"
+)
+
+var (
+	nodeInfo nodeData
+)
+
+// Fetch information on the Knfsd node
+func init() {
+
+	// Populate Node Info
+	nodeInfo = nodeData{}
+	err := nodeInfo.fetch()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create Logging Directory if it does not exist
+	err = os.MkdirAll("/var/log/knfsd-agent", os.ModePerm)
+	if err != nil {
+		log.Fatalf("Error creating logging directory: %s", err.Error())
+	}
+
+	// Setup Logging
+	file, err := os.OpenFile("/var/log/knfsd-agent/agent.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		log.Fatalf("Error creating logging file: %s", err.Error())
+	}
+	log.SetOutput(file)
+
+}
+
+// Define a server type
+type server struct{}
+
+func main() {
+
+	// Create a HTTP Mux
+	mux := http.NewServeMux()
+
+	// Create Server
+	s := server{}
+
+	// Register all API Routes
+	s.routes(mux)
+
+	// Listen and Serve
+	log.Println("Knfsd Agent is listening on web server port 80...")
+	http.ListenAndServe(":80", mux)
+
+}

--- a/image/knfsd-agent/src/metadata.go
+++ b/image/knfsd-agent/src/metadata.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	metadataServerURL = "http://metadata.google.internal"
+)
+
+// getMetadataValue fetches a metadata path from the GCE Metadata Server returning the output as a string
+// if delimit is set to true then it will return the string after the last occurrence of /
+func getMetadataValue(URI string, delimit bool) (string, error) {
+
+	// Make a HTTP Client
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	// Build Request Object
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s?alt=text", metadataServerURL, URI), nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Set Headers
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	// Make the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	// Validate Response
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received invalid HTTP response code, got %d, wanted 200", resp.StatusCode)
+	}
+
+	// Return value
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	// Delimit if requested
+	if delimit {
+		return lastAfterDelimiter(string(body), "/")
+	}
+
+	// Else return full string
+	return string(body), nil
+
+}

--- a/image/knfsd-agent/src/nodeinfo.go
+++ b/image/knfsd-agent/src/nodeinfo.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// nodeData is returned as a response to /api/v1.0/nodeinfo
+type nodeData struct {
+	Name            string `json:"name"`
+	Hostname        string `json:"hostname"`
+	InterfaceConfig struct {
+		IPAddress   string `json:"ipAddress"`
+		NetworkName string `json:"networkName"`
+		NetworkURI  string `json:"networkURI"`
+	} `json:"interfaceConfig"`
+	Zone        string `json:"zone"`
+	MachineType string `json:"machineType"`
+	Image       string `json:"image"`
+}
+
+// fetch populates the nodeData type from the GCE Metadata Server
+func (n *nodeData) fetch() error {
+
+	var err error
+
+	// Populate Name
+	n.Name, err = getMetadataValue("computeMetadata/v1/instance/name", false)
+	if err != nil {
+		return err
+	}
+
+	// Populate Hostname
+	n.Hostname, err = getMetadataValue("computeMetadata/v1/instance/hostname", false)
+	if err != nil {
+		return err
+	}
+
+	// Populate Instance IP Address
+	n.InterfaceConfig.IPAddress, err = getMetadataValue("computeMetadata/v1/instance/network-interfaces/0/ip", false)
+	if err != nil {
+		return err
+	}
+
+	// Populate the Network URI
+	n.InterfaceConfig.NetworkURI, err = getMetadataValue("computeMetadata/v1/instance/network-interfaces/0/network", false)
+	if err != nil {
+		return err
+	}
+
+	// Populate the Network Name
+	n.InterfaceConfig.NetworkName, err = lastAfterDelimiter(n.InterfaceConfig.NetworkURI, "/")
+	if err != nil {
+		return err
+	}
+
+	// Populate the Instance Zone
+	n.Zone, err = getMetadataValue("computeMetadata/v1/instance/zone", true)
+	if err != nil {
+		return err
+	}
+
+	// Populate the Machine Type
+	n.MachineType, err = getMetadataValue("computeMetadata/v1/instance/machine-type", true)
+	if err != nil {
+		return err
+	}
+
+	// Populate the Image
+	n.Image, err = getMetadataValue("computeMetadata/v1/instance/image", false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+// handleProcess handles requests sent to the /api/vx.x/nodeinfo endpoint
+func handleProcess(w http.ResponseWriter, r *http.Request) (int, error) {
+
+	// Encode JSON
+	resp, err := json.MarshalIndent(&nodeInfo, "", "  ")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return http.StatusInternalServerError, err
+	}
+
+	// Write response
+	w.WriteHeader(http.StatusOK)
+	w.Write(resp)
+
+	// Return status code and error
+	return http.StatusOK, nil
+
+}

--- a/image/knfsd-agent/src/routes.go
+++ b/image/knfsd-agent/src/routes.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// Custom HandlerFunc that returns the status code and any errors
+type HandlerFunc func(http.ResponseWriter, *http.Request) (int, error)
+
+// routes() holds all of the server routes
+func (s *server) routes(mux *http.ServeMux) {
+	mux.HandleFunc("/", s.handlerWrapper(handleProcess))                                          // Handler for /api/{version}/nodeinfo
+	mux.HandleFunc(fmt.Sprintf("/api/v%s/nodeInfo", apiVersion), s.handlerWrapper(handleProcess)) // Handler for /api/{version}/nodeinfo
+}
+
+// handleWrapper is a middleware function to handle common tasks such as setting response headers
+func (s *server) handlerWrapper(h HandlerFunc) http.HandlerFunc {
+
+	// Return the hander func
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		// Set the Content-Type headers
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle Request
+		status, err := h(w, r)
+
+		// Prep Error Message
+		var errMsg string
+
+		// Handle error
+		if err != nil {
+			w.Write([]byte("{\"message\": \"An unknown error occurred\"}"))
+			errMsg = err.Error()
+		}
+
+		// Log Request
+		log.Printf("%s %s %s %d %s", r.RemoteAddr, r.Method, r.URL, status, errMsg)
+
+	}
+
+}

--- a/image/knfsd-agent/src/util.go
+++ b/image/knfsd-agent/src/util.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+// lastAfterDelimiter returns the string after the last occurrence of a delimiter
+func lastAfterDelimiter(path string, seperator string) (string, error) {
+
+	split := strings.Split(path, seperator)
+
+	if len(split) == 0 {
+		return "", errors.New("slice length was 0")
+	}
+
+	return split[len(split)-1], nil
+
+}

--- a/image/scripts/1_build_image.sh
+++ b/image/scripts/1_build_image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ SHELL_DEFAULT='\033[0m'
 
 # install_nfs_packages() installs NFS Packages
 install_nfs_packages() {
-    
+
     # Install Cachefilesd
     echo "Installing cachefilesd and rpcbind..."
     echo -e "------${SHELL_DEFAULT}"
@@ -109,6 +109,34 @@ install_stackdriver_agent() {
 
 }
 
+# install_golang() installs golang
+install_golang() {
+
+    echo "Installing golang...."
+    echo -e "------${SHELL_DEFAULT}"
+    cd ~
+    curl -o go1.17.3.linux-amd64.tar.gz https://dl.google.com/go/go1.17.3.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.3.linux-amd64.tar.gz
+    export PATH=$PATH:/usr/local/go/bin
+    echo -e -n "${SHELL_YELLOW}------ "
+    echo "DONE"
+
+}
+
+# install_knfsd_agent() installs the knfsd-agent (see https://github.com/GoogleCloudPlatform/knfsd-cache-utils/tree/main/image/knfsd-agent)
+install_knfsd_agent() {
+
+    echo "Installing knfsd-agent...."
+    echo -e "------${SHELL_DEFAULT}"
+    cd /root/knfsd-agent/src
+    go build -o /usr/local/bin/knfsd-agent *.go
+    cp /root/knfsd-agent/knfsd-logrotate.conf /etc/logrotate.d/
+    cp /root/knfsd-agent/knfsd-agent.service /etc/systemd/system/
+    echo -e -n "${SHELL_YELLOW}------ "
+    echo "DONE"
+
+}
+
 # download_kernel() downloads the 5.11.8 Kernel
 download_kernel() {
 
@@ -147,6 +175,8 @@ install_build_dependencies
 download_nfs-utils
 build_install_nfs-utils
 install_stackdriver_agent
+install_golang
+install_knfsd_agent
 download_kernel
 install_kernel
 


### PR DESCRIPTION
This PR implements a new agent that runs on all Knfsd instances in a cluster. It provides a HTTP API for interacting with Knfsd.

Currently the Knfsd Agent only supports a basic informational API method (`/api/v1.0/nodeinfo`). This method provides basic information on the Knfsd node. It is useful for determining which backend node you are connected to when connecting to the Knfsd Cluster via the Internal Load Balancer.

Over time this will API will be expanded with additional capabilities.