### PR TITLE
Stop reporting file system usage metrics for NFS mounts

### DIFF
--- a/deployment/terraform-module-knfsd/resources/monitoring/knfsd.conf
+++ b/deployment/terraform-module-knfsd/resources/monitoring/knfsd.conf
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+<Plugin "df">
+  # Do not report device metrics on mounted NFS shares. This can cause
+  # an excessive amount of logging if the proxy mounts thousands of NFS shares.
+  FSType "devfs"
+  FSType "nfs"
+  IgnoreSelected true
+  ReportByDevice true
+  ValuesPercentage true
+</Plugin>
+
 LoadPlugin exec
 <Plugin "exec">
     Exec "nobody" "/etc/stackdriver/knfsd-export.sh"

--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -1,1 +1,11 @@
 # Next
+
+* (GCP) Stop reporting file system usage metrics for NFS mounts
+
+## (GCP) Stop reporting file system usage metrics for NFS mounts
+
+The default stackdriver collectd configuration for the `df` plugin includes metrics for NFS shares. The df plugin only collects basic metrics such as disk free space, inode free space, etc.
+
+Collecting these metrics about NFS shares from the proxy is largely pointless as the same metrics are also available from the source server.
+
+If the proxy has hundreds or thousands of NFS exports mounted this can greatly increase the volume of metrics being collected, leading to excessive charges for metrics ingestion.


### PR DESCRIPTION
The default stackdriver collectd configuration for the df plugin includes
metrics for NFS shares. The df plugin only collects basic metrics such as
disk free space, inode free space, etc.

Collecting these metrics about NFS shares from the proxy is largely
pointless as the same metrics are also available from the source server.

If the proxy has hundreds or thousands of NFS exports mounted this can
greatly increase the volume of metrics being collected, leading to
excessive charges for metrics ingestion.