### PR TITLE
Changed Ubuntu image family and packages versions.

### DIFF
--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -1,10 +1,20 @@
 # Next
 
+* (GCP) Use LTS versions of Ubuntu
+* (GCP) Use a smaller machine type when building the image
 * (GCP) Stop reporting file system usage metrics for NFS mounts
 * (GCP) Implement the knfsd-agent which provides a HTTP API for interacting with Knfsd nodes
 * (GCP) Remove --manage-gids from RPCMOUNTDOPTS
 * (GCP) Add ability to explicitly disable NFS Versions in `nfs-kernel-server` and default to disabling NFS versions `4.0`, `4.1`, and `4.2`
 * (GCP) Remove the metadata server read sleep from `proxy-startup.sh`
+
+## (GCP) Use LTS versions of Ubuntu
+
+LTS (Long-Term Support) versions of Ubuntu are preferred for stability. These versions are supported for longer a longer period of time thus require less frequent updates to new major versions. LTS versions are normally released every 2 years and supported for 5 years. Non-LTS versions are only supported for 9 months and released every 6 months.
+
+## (GCP) Use a smaller machine type when building the image
+
+Sometimes c2-standard-32 instances are unavailable in a specific zone. The build machine was changed to use a more available machine type. A larger machine type can be used to improve the build times if they're too slow.
 
 ## (GCP) Stop reporting file system usage metrics for NFS mounts
 

--- a/image/README.md
+++ b/image/README.md
@@ -9,6 +9,17 @@ This directory contains scripts that will automatically take a vanilla Ubuntu 20
 
 For details of the patches that are applied, see [1_build_image.sh](scripts/1_build_image.sh).
 
+## Essential Package Versions
+
+For the image we are using a specific version for this packages:
+
+* stackdriver-agent=6.1.4-1.focal
+* cachefilesd=0.10.10-0.2ubuntu1
+* rpcbind=1.2.5-8
+* nfs-kernel-server=1:1.3.4-2.5ubuntu3.4
+* nfs-utils=2.5.3
+* kernel=5.11.8-051108
+
 ## Usage
 
 ### Navigate to Image Directory
@@ -31,12 +42,16 @@ export IMAGE_NAME="${IMAGE_FAMILY}-$(date -u +%F-%H%M%S)"
 
 ### Create Build Machine
 
+The standard machine type is e2-standard-8, you can use a higher one if you want to improve build speed.
+
+**IMPORTANT:** It is recommended not to change the disk boot-disk-size. The performance can increase but the image size will be larger and this will force any VMs to use the larger size drive.
+
 ```bash
 gcloud compute instances create $BUILD_MACHINE_NAME \
     --zone=$BUILD_MACHINE_ZONE \
-    --machine-type=c2-standard-16 \
+    --machine-type=e2-standard-8 \
     --project=$GOOGLE_CLOUD_PROJECT \
-    --image=ubuntu-2010-groovy-v20210323 \
+    --image-family=ubuntu-2004-lts \
     --image-project=ubuntu-os-cloud \
     --network=$BUILD_MACHINE_NETWORK \
     --subnet=$BUILD_MACHINE_SUBNET \

--- a/image/resources/scripts/1_build_image.sh
+++ b/image/resources/scripts/1_build_image.sh
@@ -28,7 +28,7 @@ install_nfs_packages() {
     echo "Installing cachefilesd and rpcbind..."
     echo -e "------${SHELL_DEFAULT}"
     apt-get update
-    apt-get install -y cachefilesd rpcbind nfs-kernel-server tree
+    apt-get install -y cachefilesd=0.10.10-0.2ubuntu1 rpcbind=1.2.5-8 nfs-kernel-server=1:1.3.4-2.5ubuntu3.4 tree
     echo "RUN=yes" >> /etc/default/cachefilesd
     systemctl disable cachefilesd
     systemctl disable nfs-kernel-server
@@ -46,7 +46,7 @@ install_build_dependencies() {
     echo -e "------${SHELL_DEFAULT}"
     apt-get update
     apt-get upgrade -y
-    apt-get install libncurses-dev flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf dwarves build-essential libevent-dev libsqlite3-dev libblkid-dev libkeyutils-dev libdevmapper-dev -y
+    apt-get install libtirpc-dev libncurses-dev flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf dwarves build-essential libevent-dev libsqlite3-dev libblkid-dev libkeyutils-dev libdevmapper-dev -y
     echo -e -n "${SHELL_YELLOW}------ "
     echo "DONE"
 
@@ -91,7 +91,7 @@ install_stackdriver_agent() {
     curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
     bash add-monitoring-agent-repo.sh
     apt-get update
-    sudo apt-get install -y stackdriver-agent
+    sudo apt-get install -y stackdriver-agent=6.1.4-1.focal
     systemctl disable stackdriver-agent
     echo -e -n "${SHELL_YELLOW}------ "
     echo "DONE"


### PR DESCRIPTION
* Change the image family to use LTS version of Ubuntu (currently 20.04)
* Document which software versions used when building the image
* Use a more available machine type when building the image