### PR TITLE
Remove --managed-gids from RCPMOUNTDOPTS

### DIFF
--- a/deployment/terraform-module-knfsd/resources/nfs-kernel-server-conf
+++ b/deployment/terraform-module-knfsd/resources/nfs-kernel-server-conf
@@ -4,10 +4,10 @@ RPCNFSDCOUNT=8
 RPCNFSDPRIORITY=0
 # Options for rpc.mountd.
 # If you have a port-based firewall, you might want to set up
-# a fixed port here using the --port option. For more information, 
+# a fixed port here using the --port option. For more information,
 # see rpc.mountd(8) or http://wiki.debian.org/SecuringNFS
 # To disable NFSv4 on the server, specify '--no-nfs-version 4' here
-RPCMOUNTDOPTS="--manage-gids"
+RPCMOUNTDOPTS=""
 # Do you want to start the svcgssd daemon? It is only required for Kerberos
 # exports. Valid alternatives are "yes" and "no"; the default is "no".
 NEED_SVCGSSD=""

--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -2,8 +2,7 @@
 
 * (GCP) Stop reporting file system usage metrics for NFS mounts
 * (GCP) Implement the knfsd-agent which provides a HTTP API for interacting with Knfsd nodes
-
-
+* (GCP) Remove --manage-gids from RPCMOUNTDOPTS
 
 ## (GCP) Stop reporting file system usage metrics for NFS mounts
 
@@ -18,3 +17,13 @@ If the proxy has hundreds or thousands of NFS exports mounted this can greatly i
 Implements a new Golang based knfsd-agent which runs on all Knfsd nodes. It provides a HTTP API that can be used for interacting with Knfsd nodes. [See here](../../image/knfsd-agent/README.md) for more information.
 
 If upgrading from `v.0.4.0` and below you will need to build a [new version of the Knfsd Image](../../image).
+
+## (GCP) Remove --manage-gids from RPCMOUNTDOPTS
+
+The `--manage-gids` option causes NFS to ignore the user’s auxiliary groups and look them up based on the local system. The reason for this option is NFS v3 supports a maximum of 16 auxiliary groups.
+
+This was causing the NFS proxy to ignore the auxiliary groups in the incoming NFS request and replace them with supplementary groups from the local system. Since the NFS proxy does not have any users configured and is not connected to LDAP this effectively removes all the supplementary groups from the user.
+
+When the proxy then sends the request to the source server, the new request was missing the auxiliary groups. This would cause permission errors when accessing files that depended on those auxiliary groups.
+
+The `--manage-gids` option only makes sense if the proxy is connected to LDAP.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,3 +78,11 @@ When using the proxy, the proxy cannot distinguish between a standard `GETATTR` 
 `acdirmin` and `acdirmax` can be used to adjust directory metadata's expiry time on the proxy. Lowering this will force the proxy to re-validate the metadata with the source more often. This will result in the proxy detecting changes to the source more quickly but increase the number of metadata requests sent by the proxy to the source.
 
 The proxy will still cache the `READDIR` results even after the directory metadata has expired. If the directory metadata (`mtime`) still matches the proxy will continue to use the cached `READDIR` results.
+
+## Supplementary Groups
+
+The NFS protocol only supports a maximum of 16 supplementary (auxiliary) groups when using UNIX (`sec=sys`) authentication.
+
+If your system relies on users with more than 16 supplementary groups the NFS proxy will need to be connected to LDAP so that the proxy can resolve the full list of groups for a user.
+
+Once connected to LDAP you need to add `--manage-gids` to the `RPCMOUNTDOPTS` in the `/etc/default/nfs-kernel-server` file.


### PR DESCRIPTION
The managed-gids option causes the NFS server to ignore the auxiliary gids
from the incoming request. Instead the server looks up the the user's
supplementary groups from the local system. This is intended to support
users with more than 16 groups (as the NFS protocol only allows a maximum
of 16).

However, this does not make sense on the proxy, as the proxy is unaware of
users and groups. To support this feature the proxy would need to be
connected to something like LDAP.

The side-effect of this is that the incoming request has all its auxiliary
groups removed. This can cause permission errors when the proxy sends a
request to the source server.