### PR TITLE
Remove sleep before metadata server queries

### DIFF
--- a/deployment/terraform-module-knfsd/resources/proxy-startup.sh
+++ b/deployment/terraform-module-knfsd/resources/proxy-startup.sh
@@ -21,7 +21,6 @@ set -e
 # get_attribute() retrieves an attribute from VM Metadata Server (https://cloud.google.com/compute/docs/metadata/overview)
 # @param (str) attribute name
 function get_attribute() {
-  sleep 1
   curl -sS "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$1" -H "Metadata-Flavor: Google"
 }
 

--- a/docs/changes/next.md
+++ b/docs/changes/next.md
@@ -4,6 +4,7 @@
 * (GCP) Implement the knfsd-agent which provides a HTTP API for interacting with Knfsd nodes
 * (GCP) Remove --manage-gids from RPCMOUNTDOPTS
 * (GCP) Add ability to explicitly disable NFS Versions in `nfs-kernel-server` and default to disabling NFS versions `4.0`, `4.1`, and `4.2`
+* (GCP) Remove the metadata server read sleep from `proxy-startup.sh`
 
 ## (GCP) Stop reporting file system usage metrics for NFS mounts
 
@@ -34,3 +35,7 @@ The `--manage-gids` option only makes sense if the proxy is connected to LDAP.
 Adds the ability to explicitly disable NFS Versions in `nfs-kernel-server`. Explicitly disabling unwanted NFS versions prevents clients from accidentally auto-negotiating an undesired NFS version.
 
 With this change, by default, NFS versions `4.0`, `4.1`, and `4.2` are now disabled on all proxies. To enable it, set a custom value for `DISABLED_NFS_VERSIONS`.
+
+## (GCP) Remove the metadata server read sleep from `proxy-startup.sh`
+
+Removes the legacy 1 second sleep that is performed before each call to the GCP Metadata server. This speeds up proxy startup by ~20 seconds.


### PR DESCRIPTION
This PR removes the legacy 1 second sleep that is performed before each call to the GCP Metadata server. This speeds up proxy startup by ~20 seconds.