### PR TITLE
Allow gVNIC without requiring the high bandwidth option

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -57,7 +57,7 @@ output "dns_name" {
 }
 ```
 
-Edit the above [configuration variables](#Configuration-Variables) to match your desired configuration.
+Edit the above [configuration variables](#configuration-variables) to match your desired configuration.
 
 ### Deploy Knfsd
 
@@ -91,7 +91,8 @@ terraform apply
 | ENABLE_UDP                          | Create a load balancer to support UDP traffic to the NFS proxy instances (when `TRAFFIC_DISTRIBUTION_MODE = "loadbalancer"`). UDP is not recommended for the main NFS traffic as it can cause data corruption. However, this maybe useful for older clients that default to using UDP for the mount protocol.                                                                                                                                                                                                      | False    | `false`                              |
 | DNS_NAME                            | The fully qualified DNS name (FQDN) to use for the KNFSD proxy cluster when `TRAFFIC_DISTRIBUTION_MODE = "round_robin_dns"`. This must end with a period, such as `rendercluster1.gcp.example.com.` or `rendercluster1.knfsd.internal.`.                                                                                                                                                                                                                                                                           | False    | `"{PROXY_BASENAME}.knfsd.internal."` |
 | ASSIGN_STATIC_IPS                   | If set to `true`, configures the MIG to use [stateful IP addresses](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-ip-addresses-in-migs). If an instance is replaced due to an update or failing health check the new instance will keep the same IP address as the original instance.                                                                                                                                                                                                 | False    | `false`                              |
-| ENABLE_HIGH_BANDWIDTH_CONFIGURATION | If set to `true` enables [gVNIC](https://cloud.google.com/compute/docs/networking/using-gvnic) and [Tier 1 Bandwidth](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for higher egress. When enabled, only N2, N2D, C2 or C2D VM's are supported. You should also make sure you [assign enough vCPU's](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration#bandwidth-tiers) to take advantage of this configuration. | False    | null                                 |
+| ENABLE_HIGH_BANDWIDTH_CONFIGURATION | If set to `true` enables [gVNIC](https://cloud.google.com/compute/docs/networking/using-gvnic) and [Tier 1 Bandwidth](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for higher egress. When enabled, only N2, N2D, C2 or C2D VM's are supported. You should also make sure you [assign enough vCPU's](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration#bandwidth-tiers) to take advantage of this configuration. | False    | `false`                                 |
+| ENABLE_GVNIC | If set to `true`, enables [gVNIC](https://cloud.google.com/compute/docs/networking/using-gvnic) for optimal network performance. | False | `false` |
 
 ### Health Check Configuration
 
@@ -216,7 +217,6 @@ These mount options are for the proxy to the source server.
 | -------------- | --------------------------------------------------------------------------------- | -------- | ------- |
 | NOHIDE         | When `true`, adds the `nohide` option to all the exports.                         | False    | `true`  |
 | EXPORT_OPTIONS | Any custom NFS exports options. These options will be applied to all NFS exports. | False    | `""`    |
-
 
 ### Autoscaling Configuration
 

--- a/deployment/terraform-module-knfsd/compute.tf
+++ b/deployment/terraform-module-knfsd/compute.tf
@@ -69,7 +69,7 @@ resource "google_compute_instance_template" "nfsproxy-template" {
     network            = var.NETWORK
     subnetwork         = var.SUBNETWORK
     subnetwork_project = var.SUBNETWORK_PROJECT != "" ? var.SUBNETWORK_PROJECT : null
-    nic_type           = var.ENABLE_HIGH_BANDWIDTH_CONFIGURATION ? "GVNIC" : "VIRTIO_NET"
+    nic_type           = (var.ENABLE_HIGH_BANDWIDTH_CONFIGURATION || var.ENABLE_GVNIC) ? "GVNIC" : "VIRTIO_NET"
   }
 
   metadata = {

--- a/deployment/terraform-module-knfsd/variables.tf
+++ b/deployment/terraform-module-knfsd/variables.tf
@@ -400,3 +400,8 @@ variable "ENABLE_HIGH_BANDWIDTH_CONFIGURATION" {
   type    = bool
   default = false
 }
+
+variable "ENABLE_GVNIC" {
+  type    = bool
+  default = false
+}

--- a/docs/changes/changelog.md
+++ b/docs/changes/changelog.md
@@ -4,6 +4,7 @@
 * Update to the latest FS-Cache performance patches (v11)
 * Assign static IPs to proxy instances
 * DNS Round Robin based load balancing
+* Allow gVNIC without requiring the high bandwidth option
 
 ## Change the default build machine type to c2-standard-16
 
@@ -39,6 +40,12 @@ Add a new configuration option, `TRAFFIC_DISTRIBUTION_MODE`, to choose between u
 DNS round robin uses Cloud DNS to distribute the traffic between the different proxy instances in a KNFSD proxy instance group.
 
 DNS round robin is the recommended method, however making this the default could cause unintended changes to existing deployments. To avoid this the `TRAFFIC_DISTRIBUTION_MODE` is required and has no default.
+
+## Allow gVNIC without requiring the high bandwidth option
+
+Add a new configuration option, `ENABLE_GVNIC`, to use the `gVNIC` network interface type even if  `ENABLE_HIGH_BANDWIDTH_CONFIGURATION` is not enabled.
+
+This will allow the use of the more performant `gVNIC` instead of the default `virtio` driver on smaller instances, or where there is no need for the TIER_1 network performance.
 
 # v1.0.0-beta3
 
@@ -310,7 +317,6 @@ When the health check is enabled, after 10 minutes the proxy instance will be re
 ## Custom GCP labels for proxy VM instances
 
 Added a new `PROXY_LABELS` variable to set custom labels on the proxy VM instances. This can aid with filtering metrics and logs when running multiple proxy clusters in a single project.
-
 
 # v0.5.1
 


### PR DESCRIPTION
Add a new configuration option, `ENABLE_GVNIC`, to use the `gVNIC` network interface type even if  `ENABLE_HIGH_BANDWIDTH_CONFIGURATION` is not enabled.

This will allow the use of the more performant `gVNIC` instead of the default `virtio` driver on smaller instances, or where there is no need for the TIER_1 network performance.