### PR TITLE
Update proxy-startup.sh so LocalSSD NVMe will not to conflict with PD NVMe

### DIFF
--- a/tutorial/proxy-startup.sh
+++ b/tutorial/proxy-startup.sh
@@ -30,9 +30,9 @@ NFS_MOUNT_POINT="/data"
 
 function create-fs-cache() {
 	# List attatched NVME local SSDs
-	echo "Detecting local NVMe drives..."
-	DRIVESLIST=$(/bin/ls /dev/nvme0n*)
-	NUMDRIVES=$(/bin/ls /dev/nvme0n* | wc -w)
+	echo "Detecting local SSDs drives..."
+	DRIVESLIST=$(/bin/find /dev/disk/by-id/google-local-* | grep -v -E '\-part[0-9]+$')
+	NUMDRIVES=$(/bin/find /dev/disk/by-id/google-local-* | grep -v -E '\-part[0-9]+$' | wc -w)
 	echo "Detected $NUMDRIVES drives. Names: $DRIVESLIST."
 
 	# If there are local NVMe drives attached, start the process of formatting and mounting


### PR DESCRIPTION
Newer machine families only supports NVMe Persistent Disks. 
- With the current approach, those would be included in the list, including the boot disk. 
- Per [documentation](https://cloud.google.com/compute/docs/disks/add-local-ssd#formatindividual) this proposition would take only LocalSSD  (both SCSI & NVMe), and won't likely conflict with Persistent Disk.