### PR TITLE
Update 1_build_image.sh: gcc-12 required for kernel 6.4 build

### DIFF
--- a/image/resources/scripts/1_build_image.sh
+++ b/image/resources/scripts/1_build_image.sh
@@ -69,7 +69,7 @@ install_build_dependencies() {
         build-essential libevent-dev libsqlite3-dev libblkid-dev \
         libmount-dev libwrap0-dev libkrb5-dev libldap2-dev libcap-dev \
         libkeyutils-dev libdevmapper-dev cdbs debhelper ubuntu-dev-tools \
-        gawk llvm pkg-config
+        gawk llvm pkg-config gcc-12
     complete_command
 }
 


### PR DESCRIPTION
Building 6.4 kernel fails because it requires gcc-12. This version is available natively on ubuntu 22.04+